### PR TITLE
Global allocators

### DIFF
--- a/.github/workflows/test-features.yml
+++ b/.github/workflows/test-features.yml
@@ -13,9 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        alloc: ["", "alloc,"]
+        std: ["", "alloc,", "std,"]
         sync: ["", "sync,"]
-        oom_handling: ["", "oom_handling,"]
         nightly: ["", "nightly,"]
     steps:
     - uses: actions/checkout@v2
@@ -28,4 +27,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all --features=${{ matrix.alloc }}${{ matrix.sync }}${{ matrix.oom_handling }}${{ matrix.nightly }}
+        args: --all --features=${{ matrix.std }}${{ matrix.sync }}${{ matrix.nightly }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2023-03-07
+
+### Added 
+- `GlobalBlinkAlloc` - allocator suitable for use as `#[global_allocator]`
+  Based on `SyncBlinkAlloc`. Provides local proxies that may be `'static`
+  Unsafe `reset` method requires that all local proxies
+  and previous allocations are dropped.
+- `UnsafeGlobalAlloc` - more unsafe version of `GlobalBlinkAlloc`.
+  It must never be used concurrently. Only really usable in single-threaded
+  applications.
+  Requires `unsafe` block to initialize.
 
 ## [0.1.0] - 2023-02-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["std"]
 [dependencies]
 parking_lot = {  version = "0.12", optional = true }
 sptr = "0.3"
-allocator-api2 = { version = "0.2.1", default-features = false, path = "../allocator-api2" }
+allocator-api2 = { version = "0.2.4", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["std"]
 [dependencies]
 parking_lot = {  version = "0.12", optional = true }
 sptr = "0.3"
-allocator-api2 = { version = "0.2.1", default-features = false }
+allocator-api2 = { version = "0.2.1", default-features = false, path = "../allocator-api2" }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blink-alloc"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2018"
 authors = ["Zakarum <zaq.dev@icloud.com>"]
 license = "MIT OR Apache-2.0"
@@ -14,10 +14,10 @@ keywords = ["allocator", "arena", "concurrent", "drop"]
 [features]
 nightly = ["allocator-api2/nightly", "bumpalo/allocator_api"]
 alloc = ["allocator-api2/alloc"]
-oom_handling = []
-sync = ["parking_lot"]
+std = ["alloc", "allocator-api2/std",]
+sync = ["parking_lot", "std"]
 
-default = ["alloc", "oom_handling"]
+default = ["std"]
 
 [dependencies]
 parking_lot = {  version = "0.12", optional = true }
@@ -32,6 +32,10 @@ bumpalo = "3.7"
 name = "bench"
 harness = false
 required-features = ["alloc", "sync", "nightly"]
+
+[[example]]
+name = "global"
+required-features = ["std", "sync"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Initialize and start putting values there.
 ```rust
 use blink_alloc::Blink;
 
+#[cfg(feature = "alloc")]
 fn main() {
     // `Blink::new` uses `BlinkAlloc<Global>`
     let mut blink = Blink::new();
@@ -154,23 +155,25 @@ fn main() {
     assert_eq!(&*slice, &[1, 2, 4, 5, 7, 8]);
     blink.reset();
 }
+#[cfg(not(feature = "alloc"))] fn main() {}
 ```
 
 ```rust
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 use blink_alloc::BlinkAlloc;
 
+#[cfg(feature = "alloc")]
 fn main() {
-    #[cfg(feature = "nightly")]
-    {
-        let mut blink = BlinkAlloc::new();
-        let mut vec = Vec::new_in(&blink);
-        vec.extend((1..10).map(|x| x * 3 - 2));
+    use allocator_api2::vec::Vec;
 
-        drop(vec);
-        blink.reset();
-    }
+    let mut blink = BlinkAlloc::new();
+    let mut vec = Vec::new_in(&blink);
+    vec.extend((1..10).map(|x| x * 3 - 2));
+
+    drop(vec);
+    blink.reset();
 }
+#[cfg(not(feature = "alloc"))] fn main() {}
 ```
 
 # No-std

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -517,17 +517,17 @@ where
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    // bench_alloc::<BlinkAlloc>("blink_alloc::BlinkAlloc", c);
-    // bench_alloc::<SyncBlinkAlloc>("blink_alloc::SyncBlinkAlloc", c);
-    // bench_alloc::<bumpalo::Bump>("bumpalo::Bump", c);
+    bench_alloc::<BlinkAlloc>("blink_alloc::BlinkAlloc", c);
+    bench_alloc::<SyncBlinkAlloc>("blink_alloc::SyncBlinkAlloc", c);
+    bench_alloc::<bumpalo::Bump>("bumpalo::Bump", c);
 
-    // bench_warm_up::<BlinkAlloc>("blink_alloc::BlinkAlloc", c);
-    // bench_warm_up::<SyncBlinkAlloc>("blink_alloc::SyncBlinkAlloc", c);
-    // bench_warm_up::<bumpalo::Bump>("bumpalo::Bump", c);
+    bench_warm_up::<BlinkAlloc>("blink_alloc::BlinkAlloc", c);
+    bench_warm_up::<SyncBlinkAlloc>("blink_alloc::SyncBlinkAlloc", c);
+    bench_warm_up::<bumpalo::Bump>("bumpalo::Bump", c);
 
-    // bench_vec::<BlinkAlloc>("blink_alloc::BlinkAlloc", c);
-    // bench_vec::<SyncBlinkAlloc>("blink_alloc::SyncBlinkAlloc", c);
-    // bench_vec::<bumpalo::Bump>("bumpalo::Bump", c);
+    bench_vec::<BlinkAlloc>("blink_alloc::BlinkAlloc", c);
+    bench_vec::<SyncBlinkAlloc>("blink_alloc::SyncBlinkAlloc", c);
+    bench_vec::<bumpalo::Bump>("bumpalo::Bump", c);
 
     bench_from_iter::<Blink<BlinkAlloc>>("blink_alloc::BlinkAlloc", c);
     bench_from_iter::<Blink<SyncBlinkAlloc>>("blink_alloc::SyncBlinkAlloc", c);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -535,9 +535,4 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 }
 
 criterion_group!(benches, criterion_benchmark);
-// criterion_main!(benches);
-
-fn main() {
-    benches();
-    Criterion::default().configure_from_args().final_summary();
-}
+criterion_main!(benches);

--- a/examples/global.rs
+++ b/examples/global.rs
@@ -1,0 +1,13 @@
+use blink_alloc::GlobalBlinkAlloc;
+
+#[global_allocator]
+static GLOBAL_ALLOC: GlobalBlinkAlloc = GlobalBlinkAlloc::new();
+
+fn main() {
+    let _ = Box::new(42);
+    let _ = vec![1, 2, 3];
+
+    unsafe {
+        GLOBAL_ALLOC.reset();
+    }
+}

--- a/examples/global.rs
+++ b/examples/global.rs
@@ -4,6 +4,10 @@ use blink_alloc::GlobalBlinkAlloc;
 static GLOBAL_ALLOC: GlobalBlinkAlloc = GlobalBlinkAlloc::new();
 
 fn main() {
+    unsafe {
+        GLOBAL_ALLOC.scope();
+    }
+
     let _ = Box::new(42);
     let _ = vec![1, 2, 3];
 

--- a/examples/global.rs
+++ b/examples/global.rs
@@ -5,7 +5,7 @@ static GLOBAL_ALLOC: GlobalBlinkAlloc = GlobalBlinkAlloc::new();
 
 fn main() {
     unsafe {
-        GLOBAL_ALLOC.scope();
+        GLOBAL_ALLOC.init();
     }
 
     let _ = Box::new(42);

--- a/examples/global.rs
+++ b/examples/global.rs
@@ -5,13 +5,13 @@ static GLOBAL_ALLOC: GlobalBlinkAlloc = GlobalBlinkAlloc::new();
 
 fn main() {
     unsafe {
-        GLOBAL_ALLOC.init();
+        GLOBAL_ALLOC.blink_mode();
     }
 
     let _ = Box::new(42);
     let _ = vec![1, 2, 3];
 
     unsafe {
-        GLOBAL_ALLOC.reset();
+        GLOBAL_ALLOC.direct_mode();
     }
 }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -1107,17 +1107,6 @@ use crate::cold;
 #[cfg(feature = "sync")]
 pub use self::sync::ArenaSync;
 
-// #[cfg(debug_assertions)]
-// #[track_caller]
-// unsafe fn unreachable_unchecked() -> ! {
-//     unreachable!()
-// }
-
-// #[cfg(not(debug_assertions))]
-// unsafe fn unreachable_unchecked() -> ! {
-//     unsafe { core::hint::unreachable_unchecked() }
-// }
-
 // #[inline(always)]
 // unsafe fn memmove(src: *mut u8, dst: *mut u8, size: usize) {
 //     if src == dst {

--- a/src/blink.rs
+++ b/src/blink.rs
@@ -389,26 +389,26 @@ where
             #[inline(always)]
             fn flush(&mut self) -> &'a mut [T] {
                 match self.ptr.take() {
-                    Some(mut ptr) if self.count != 0 => {
-                        if self.count < self.cap {
-                            // shrink the allocation to the actual size.
-                            // `BlinkAllocator` guarantees that this will not fail
-                            // be a no-op.
+                    Some(ptr) if self.count != 0 => {
+                        // if self.count < self.cap {
+                        //     // shrink the allocation to the actual size.
+                        //     // `BlinkAllocator` guarantees that this will not fail
+                        //     // be a no-op.
 
-                            let item_layout = Layout::new::<DropItem<[T; 0]>>();
+                        //     let item_layout = Layout::new::<DropItem<[T; 0]>>();
 
-                            let (new_layout, _) = Layout::array::<T>(self.count)
-                                .and_then(|array| item_layout.extend(array))
-                                .expect("Smaller than actual allocation");
+                        //     let (new_layout, _) = Layout::array::<T>(self.count)
+                        //         .and_then(|array| item_layout.extend(array))
+                        //         .expect("Smaller than actual allocation");
 
-                            // Safety:
-                            // Shrinking the allocation to the actual used size.
-                            let new_ptr =
-                                unsafe { self.alloc.shrink(ptr.cast(), self.layout, new_layout) }
-                                    .expect("BlinkAllocator guarantees this will succeed");
+                        //     // Safety:
+                        //     // Shrinking the allocation to the actual used size.
+                        //     let new_ptr =
+                        //         unsafe { self.alloc.shrink(ptr.cast(), self.layout, new_layout) }
+                        //             .expect("BlinkAllocator guarantees this will succeed");
 
-                            ptr = new_ptr.cast();
-                        }
+                        //     ptr = new_ptr.cast();
+                        // }
 
                         // Safety: `item` was properly initialized.
                         let (item, slice) = unsafe { DropItem::init_slice(ptr, self.count) };
@@ -574,23 +574,23 @@ where
             #[inline(always)]
             fn flush(&mut self) -> &'a mut [T] {
                 match self.ptr.take() {
-                    Some(mut ptr) if self.count != 0 => {
-                        if self.count < self.cap {
-                            // shrink the allocation to the actual size.
-                            // `BlinkAllocator` guarantees that this will not fail
-                            // be a no-op.
+                    Some(ptr) if self.count != 0 => {
+                        // if self.count < self.cap {
+                        //     // shrink the allocation to the actual size.
+                        //     // `BlinkAllocator` guarantees that this will not fail
+                        //     // be a no-op.
 
-                            let new_layout = Layout::array::<T>(self.count)
-                                .expect("Smaller than actual allocation");
+                        //     let new_layout = Layout::array::<T>(self.count)
+                        //         .expect("Smaller than actual allocation");
 
-                            // Safety:
-                            // Shrinking the allocation to the actual used size.
-                            let new_ptr =
-                                unsafe { self.alloc.shrink(ptr.cast(), self.layout, new_layout) }
-                                    .expect("BlinkAllocator guarantees this will succeed");
+                        //     // Safety:
+                        //     // Shrinking the allocation to the actual used size.
+                        //     let new_ptr =
+                        //         unsafe { self.alloc.shrink(ptr.cast(), self.layout, new_layout) }
+                        //             .expect("BlinkAllocator guarantees this will succeed");
 
-                            ptr = new_ptr.cast();
-                        }
+                        //     ptr = new_ptr.cast();
+                        // }
 
                         // Safety: reallocated for slice of size `self.count`
                         unsafe { &mut *core::slice::from_raw_parts_mut(ptr.as_ptr(), self.count) }

--- a/src/blink.rs
+++ b/src/blink.rs
@@ -123,6 +123,7 @@ pub trait IteratorExt: Iterator {
 
     /// Attempts to collect iterator into blink allocator and return slice reference.
     #[inline(always)]
+    #[allow(clippy::type_complexity)]
     fn try_collect_to_blink<A: BlinkAllocator>(
         self,
         blink: &mut Blink<A>,
@@ -136,6 +137,7 @@ pub trait IteratorExt: Iterator {
 
     /// Attempts to collect iterator into blink allocator and return slice reference.
     #[inline(always)]
+    #[allow(clippy::type_complexity)]
     fn try_collect_to_blink_shared<A: BlinkAllocator>(
         self,
         blink: &mut Blink<A>,
@@ -148,6 +150,7 @@ pub trait IteratorExt: Iterator {
 
     /// Attempts to collect iterator into blink allocator and return slice reference.
     #[inline(always)]
+    #[allow(clippy::type_complexity)]
     fn try_collect_to_blink_no_drop<A: BlinkAllocator>(
         self,
         blink: &mut Blink<A>,
@@ -1018,6 +1021,7 @@ where
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[inline(always)]
+    #[allow(clippy::mut_from_ref)]
     pub fn put<T: 'static>(&self, value: T) -> &mut T {
         unsafe {
             self._try_emplace(
@@ -1061,6 +1065,7 @@ where
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[inline(always)]
+    #[allow(clippy::mut_from_ref)]
     pub fn put_no_drop<T>(&self, value: T) -> &mut T {
         unsafe {
             self._try_emplace(

--- a/src/drop_list.rs
+++ b/src/drop_list.rs
@@ -99,6 +99,7 @@ impl DropList {
     /// # Safety
     ///
     /// `item` reference must be valid until next call to [`DropList::reset`].
+    #[allow(clippy::mut_from_ref)]
     pub unsafe fn add<'a, 'b: 'a, T: ?Sized>(&'a self, item: &'b mut DropItem<T>) -> &'a mut T {
         item.drops.next = self.root.take();
         let item = NonNull::from(item);

--- a/src/global/local.rs
+++ b/src/global/local.rs
@@ -199,7 +199,7 @@ where
         {
             assert_eq!(self.allocations.get(), 0, "Not everything was deallocated");
         }
-        (&*self.inner.get()).reset_unchecked();
+        (*self.inner.get()).reset_unchecked();
     }
 
     /// Refreshes scope of this allocator.
@@ -261,7 +261,7 @@ where
 {
     #[inline]
     unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
-        match (&*self.inner.get()).allocate(layout) {
+        match (*self.inner.get()).allocate(layout) {
             Ok(ptr) => {
                 #[cfg(debug_assertions)]
                 {
@@ -276,7 +276,7 @@ where
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
         let ptr = NonNull::new_unchecked(ptr);
-        (&*self.inner.get()).deallocate(ptr, layout.size());
+        (*self.inner.get()).deallocate(ptr, layout.size());
         #[cfg(debug_assertions)]
         {
             self.allocations
@@ -286,7 +286,7 @@ where
 
     #[inline]
     unsafe fn alloc_zeroed(&self, layout: core::alloc::Layout) -> *mut u8 {
-        match (&*self.inner.get()).allocate_zeroed(layout) {
+        match (*self.inner.get()).allocate_zeroed(layout) {
             Ok(ptr) => {
                 #[cfg(debug_assertions)]
                 {
@@ -310,8 +310,8 @@ where
         };
 
         let result = match NonNull::new(ptr) {
-            None => (&*self.inner.get()).allocate(new_layout),
-            Some(ptr) => (&*self.inner.get()).resize(ptr, layout, new_layout),
+            None => (*self.inner.get()).allocate(new_layout),
+            Some(ptr) => (*self.inner.get()).resize(ptr, layout, new_layout),
         };
 
         match result {

--- a/src/global/local.rs
+++ b/src/global/local.rs
@@ -51,6 +51,37 @@ impl UnsafeGlobalBlinkAlloc<std::alloc::System> {
             inner: BlinkAlloc::new_in(std::alloc::System),
         }
     }
+
+    /// Create a new [`UnsafeGlobalBlinkAlloc`].
+    /// With this method you can specify initial chunk size.
+    ///
+    /// Const function can be used to initialize a static variable.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because this type is not thread-safe
+    /// but implements `Sync`.
+    /// Allocator returned by this method must not be used concurrently.
+    ///
+    /// For safer alternative see [`GlobalBlinkAlloc`](https://docs.rs/blink-alloc/0.2.2/blink_alloc/struct.GlobalBlinkAlloc.html).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use blink_alloc::UnsafeGlobalBlinkAlloc;
+    ///
+    /// // Safety: This program is single-threaded.
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: UnsafeGlobalBlinkAlloc = unsafe { UnsafeGlobalBlinkAlloc::with_chunk_size(1024) };
+    ///
+    /// let _ = Box::new(42);
+    /// let _ = vec![1, 2, 3];
+    /// ```
+    pub const unsafe fn with_chunk_size(chunk_size: usize) -> Self {
+        Self {
+            inner: BlinkAlloc::with_chunk_size_in(chunk_size, std::alloc::System),
+        }
+    }
 }
 
 impl<A> UnsafeGlobalBlinkAlloc<A>
@@ -85,9 +116,44 @@ where
     /// # }
     /// # #[cfg(not(feature = "std"))] fn main() {}
     /// ```
-    pub const unsafe fn new_in(alloc: A) -> Self {
+    pub const unsafe fn new_in(allocator: A) -> Self {
         Self {
-            inner: BlinkAlloc::new_in(alloc),
+            inner: BlinkAlloc::new_in(allocator),
+        }
+    }
+
+    /// Create a new [`UnsafeGlobalBlinkAlloc`]
+    /// with specified underlying allocator.
+    /// With this method you can specify initial chunk size.
+    ///
+    /// Const function can be used to initialize a static variable.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because this type is not thread-safe
+    /// but implements `Sync`.
+    /// Allocator returned by this method must not be used concurrently.
+    ///
+    /// For safer alternative see [`GlobalBlinkAlloc`](https://docs.rs/blink-alloc/0.2.2/blink_alloc/struct.GlobalBlinkAlloc.html).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(feature = "std")] fn main() {
+    /// use blink_alloc::UnsafeGlobalBlinkAlloc;
+    ///
+    /// // Safety: This program is single-threaded.
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: UnsafeGlobalBlinkAlloc<std::alloc::System> = unsafe { UnsafeGlobalBlinkAlloc::with_chunk_size_in(1024, std::alloc::System) };
+    ///
+    /// let _ = Box::new(42);
+    /// let _ = vec![1, 2, 3];
+    /// # }
+    /// # #[cfg(not(feature = "std"))] fn main() {}
+    /// ```
+    pub const unsafe fn with_chunk_size_in(chunk_size: usize, allocator: A) -> Self {
+        Self {
+            inner: BlinkAlloc::with_chunk_size_in(chunk_size, allocator),
         }
     }
 

--- a/src/global/local.rs
+++ b/src/global/local.rs
@@ -6,32 +6,32 @@ use core::{
 
 use allocator_api2::alloc::{AllocError, Allocator};
 
-use crate::{cold, local::BlinkAlloc, unreachable_unchecked};
+use crate::{cold, local::BlinkAlloc};
 
-enum State<A: Allocator> {
-    Initialized(BlinkAlloc<A>),
-    Uninitialized(A),
+struct State<A: Allocator> {
+    blink: BlinkAlloc<A>,
+    enabled: bool,
 }
 
 impl<A: Allocator> State<A> {
     #[inline(always)]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        match self {
-            State::Initialized(blink_alloc) => blink_alloc.allocate(layout),
-            State::Uninitialized(allocator) => {
+        match self.enabled {
+            true => self.blink.allocate(layout),
+            false => {
                 cold();
-                allocator.allocate(layout)
+                self.blink.inner().allocate(layout)
             }
         }
     }
 
     #[inline(always)]
     fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        match self {
-            State::Initialized(blink_alloc) => blink_alloc.allocate_zeroed(layout),
-            State::Uninitialized(allocator) => {
+        match self.enabled {
+            true => self.blink.allocate_zeroed(layout),
+            false => {
                 cold();
-                allocator.allocate_zeroed(layout)
+                self.blink.inner().allocate_zeroed(layout)
             }
         }
     }
@@ -43,14 +43,14 @@ impl<A: Allocator> State<A> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        match self {
-            State::Initialized(blink_alloc) => blink_alloc.resize(ptr, old_layout, new_layout),
-            State::Uninitialized(allocator) => {
+        match self.enabled {
+            true => self.blink.resize(ptr, old_layout, new_layout),
+            false => {
                 cold();
                 if old_layout.size() >= new_layout.size() {
-                    allocator.grow(ptr, old_layout, new_layout)
+                    self.blink.inner().grow(ptr, old_layout, new_layout)
                 } else {
-                    allocator.shrink(ptr, old_layout, new_layout)
+                    self.blink.inner().shrink(ptr, old_layout, new_layout)
                 }
             }
         }
@@ -58,11 +58,11 @@ impl<A: Allocator> State<A> {
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        match self {
-            State::Initialized(blink_alloc) => blink_alloc.deallocate(ptr, layout.size()),
-            State::Uninitialized(allocator) => {
+        match self.enabled {
+            true => self.blink.deallocate(ptr, layout.size()),
+            false => {
                 cold();
-                allocator.deallocate(ptr, layout)
+                self.blink.inner().deallocate(ptr, layout)
             }
         }
     }
@@ -71,7 +71,7 @@ impl<A: Allocator> State<A> {
 switch_std_default! {
     /// [`GlobalAlloc`] implementation based on [`BlinkAlloc`].
     pub struct UnsafeGlobalBlinkAlloc<A: Allocator = +std::alloc::System> {
-        inner: UnsafeCell<State<A>>,
+        state: UnsafeCell<State<A>>,
         #[cfg(debug_assertions)]
         allocations: Cell<u64>,
     }
@@ -113,6 +113,39 @@ impl UnsafeGlobalBlinkAlloc<std::alloc::System> {
     pub const unsafe fn new() -> Self {
         UnsafeGlobalBlinkAlloc::new_in(std::alloc::System)
     }
+
+    /// Create a new [`UnsafeGlobalBlinkAlloc`].
+    ///
+    /// This method allows to specify initial chunk size.
+    ///
+    /// Const function can be used to initialize a static variable.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because this type is not thread-safe
+    /// but implements `Sync`.
+    /// Allocator returned by this method must not be used concurrently.
+    ///
+    /// For safer alternative see [`GlobalBlinkAlloc`](https://docs.rs/blink-alloc/0.2.2/blink_alloc/struct.GlobalBlinkAlloc.html).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(feature = "std")] fn main() {
+    /// use blink_alloc::UnsafeGlobalBlinkAlloc;
+    ///
+    /// // Safety: This program is single-threaded.
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: UnsafeGlobalBlinkAlloc<std::alloc::System> = unsafe { UnsafeGlobalBlinkAlloc::new_in(std::alloc::System) };
+    ///
+    /// let _ = Box::new(42);
+    /// let _ = vec![1, 2, 3];
+    /// # }
+    /// # #[cfg(not(feature = "std"))] fn main() {}
+    /// ```
+    pub const unsafe fn with_chunk_size(chunk_size: usize) -> Self {
+        UnsafeGlobalBlinkAlloc::with_chunk_size_in(chunk_size, std::alloc::System)
+    }
 }
 
 impl<A> UnsafeGlobalBlinkAlloc<A>
@@ -149,7 +182,51 @@ where
     /// ```
     pub const unsafe fn new_in(allocator: A) -> Self {
         UnsafeGlobalBlinkAlloc {
-            inner: UnsafeCell::new(State::Uninitialized(allocator)),
+            state: UnsafeCell::new(State {
+                blink: BlinkAlloc::new_in(allocator),
+                enabled: false,
+            }),
+            #[cfg(debug_assertions)]
+            allocations: Cell::new(0),
+        }
+    }
+
+    /// Create a new [`UnsafeGlobalBlinkAlloc`]
+    /// with specified underlying allocator.
+    ///
+    /// This method allows to specify initial chunk size.
+    ///
+    /// Const function can be used to initialize a static variable.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because this type is not thread-safe
+    /// but implements `Sync`.
+    /// Allocator returned by this method must not be used concurrently.
+    ///
+    /// For safer alternative see [`GlobalBlinkAlloc`](https://docs.rs/blink-alloc/0.2.2/blink_alloc/struct.GlobalBlinkAlloc.html).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(feature = "std")] fn main() {
+    /// use blink_alloc::UnsafeGlobalBlinkAlloc;
+    ///
+    /// // Safety: This program is single-threaded.
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: UnsafeGlobalBlinkAlloc<std::alloc::System> = unsafe { UnsafeGlobalBlinkAlloc::new_in(std::alloc::System) };
+    ///
+    /// let _ = Box::new(42);
+    /// let _ = vec![1, 2, 3];
+    /// # }
+    /// # #[cfg(not(feature = "std"))] fn main() {}
+    /// ```
+    pub const unsafe fn with_chunk_size_in(chunk_size: usize, allocator: A) -> Self {
+        UnsafeGlobalBlinkAlloc {
+            state: UnsafeCell::new(State {
+                blink: BlinkAlloc::with_chunk_size_in(chunk_size, allocator),
+                enabled: false,
+            }),
             #[cfg(debug_assertions)]
             allocations: Cell::new(0),
         }
@@ -162,7 +239,7 @@ where
     ///
     /// # Safety
     ///
-    /// Memory allocated from this allocator becomes invalidated.
+    /// Memory allocated from this allocator in blink mode becomes invalidated.
     /// The user is responsible to ensure that previously allocated memory
     /// won't be used after reset.
     ///
@@ -175,15 +252,18 @@ where
     /// #[global_allocator]
     /// static GLOBAL_ALLOC: UnsafeGlobalBlinkAlloc = unsafe { UnsafeGlobalBlinkAlloc::new() };
     ///
-    /// unsafe { GLOBAL_ALLOC.init() };
+    /// unsafe { GLOBAL_ALLOC.blink_mode() };
     ///
     /// let b = Box::new(42);
     /// let v = vec![1, 2, 3];
     /// drop(b);
     /// drop(v);
     ///
-    /// // Safety: memory allocated after `init` call won't be used after reset.
-    /// unsafe { GLOBAL_ALLOC.reset() };
+    /// // Safety: memory allocated in blink mode won't be used after reset.
+    /// unsafe {
+    ///     GLOBAL_ALLOC.reset();
+    ///     GLOBAL_ALLOC.direct_mode();
+    /// };
     /// # }
     /// # #[cfg(not(feature = "std"))] fn main() {}
     /// ```
@@ -193,55 +273,45 @@ where
         {
             assert_eq!(self.allocations.get(), 0, "Not everything was deallocated");
         }
-        match *self.inner.get() {
-            State::Initialized(ref mut allocator) => allocator.reset(),
-            State::Uninitialized(_) => cold(),
-        }
+
+        (*self.state.get()).blink.reset_unchecked();
     }
 
-    /// Initializes this allocator.
-    /// Before this call any allocation will go directly to the underlying allocator.
+    /// Switches allocator to blink mode.
+    /// All allocations will be served by blink-allocator.
+    ///
+    /// The type is created in direct mode.
+    /// When used as global allocator, user may manually switch into blink mode
+    /// in `main` or at any point later.
+    ///
+    /// However user must switch back to direct mode before returning from `main`.
     ///
     /// # Safety
     ///
-    /// Must be called exactly once.
     /// Must be externally synchronized with other threads accessing this allocator.
+    /// Memory allocated in direct mode must not be deallocated while in blink mode.
     #[inline(always)]
-    pub unsafe fn init(&self) {
-        let alloc = match core::ptr::read(self.inner.get()) {
-            State::Uninitialized(allocator) => BlinkAlloc::new_in(allocator),
-            State::Initialized(_) => unreachable_unchecked(),
-        };
-        core::ptr::write(self.inner.get(), State::Initialized(alloc));
-
-        #[cfg(debug_assertions)]
-        {
-            self.allocations.set(0);
-        }
+    pub unsafe fn blink_mode(&self) {
+        (*self.state.get()).enabled = true;
     }
 
-    /// Initializes this allocator.
-    /// With this method you can specify initial chunk size.
-    /// Before this call any allocation will go directly to the underlying allocator.
+    /// Switches allocator to blink mode.
+    /// All allocations will be served by underlying allocator.
+    ///
+    /// The type is created in direct mode.
+    /// When used as global allocator, user may manually switch into blink mode
+    /// in `main` or at any point later.
+    ///
+    /// However user must switch back to direct mode before returning from `main`.
     ///
     /// # Safety
     ///
-    /// Must be called exactly once.
     /// Must be externally synchronized with other threads accessing this allocator.
+    /// Memory allocated in blink mode must not be deallocated while in direct mode.
     #[inline(always)]
-    pub unsafe fn init_with_chunk_size(&self, chunk_size: usize) {
-        let alloc = match core::ptr::read(self.inner.get()) {
-            State::Uninitialized(allocator) => {
-                BlinkAlloc::with_chunk_size_in(chunk_size, allocator)
-            }
-            State::Initialized(_) => unreachable_unchecked(),
-        };
-        core::ptr::write(self.inner.get(), State::Initialized(alloc));
-
-        #[cfg(debug_assertions)]
-        {
-            self.allocations.set(0);
-        }
+    pub unsafe fn direct_mode(&self) {
+        self.reset();
+        (*self.state.get()).enabled = false;
     }
 }
 
@@ -251,10 +321,10 @@ where
 {
     #[inline]
     unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
-        match (*self.inner.get()).allocate(layout) {
+        match (*self.state.get()).allocate(layout) {
             Ok(ptr) => {
                 #[cfg(debug_assertions)]
-                {
+                if (*self.state.get()).enabled {
                     self.allocations.set(self.allocations.get() + 1);
                 }
                 ptr.as_ptr().cast()
@@ -266,9 +336,9 @@ where
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
         let ptr = NonNull::new_unchecked(ptr);
-        (*self.inner.get()).deallocate(ptr, layout);
+        (*self.state.get()).deallocate(ptr, layout);
         #[cfg(debug_assertions)]
-        {
+        if (*self.state.get()).enabled {
             self.allocations
                 .set(self.allocations.get().saturating_sub(1));
         }
@@ -276,10 +346,10 @@ where
 
     #[inline]
     unsafe fn alloc_zeroed(&self, layout: core::alloc::Layout) -> *mut u8 {
-        match (*self.inner.get()).allocate_zeroed(layout) {
+        match (*self.state.get()).allocate_zeroed(layout) {
             Ok(ptr) => {
                 #[cfg(debug_assertions)]
-                {
+                if (*self.state.get()).enabled {
                     self.allocations.set(self.allocations.get() + 1);
                 }
                 ptr.as_ptr().cast()
@@ -300,8 +370,8 @@ where
         };
 
         let result = match NonNull::new(ptr) {
-            None => (*self.inner.get()).allocate(new_layout),
-            Some(ptr) => (*self.inner.get()).resize(ptr, layout, new_layout),
+            None => (*self.state.get()).allocate(new_layout),
+            Some(ptr) => (*self.state.get()).resize(ptr, layout, new_layout),
         };
 
         match result {

--- a/src/global/local.rs
+++ b/src/global/local.rs
@@ -1,0 +1,178 @@
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    ptr::{null_mut, NonNull},
+};
+
+use allocator_api2::alloc::Allocator;
+
+use crate::local::BlinkAlloc;
+
+switch_std_default! {
+    /// [`GlobalAlloc`] implementation based on [`BlinkAlloc`].
+    pub struct UnsafeGlobalBlinkAlloc<A: Allocator = +std::alloc::System> {
+        inner: BlinkAlloc<A>,
+    }
+}
+
+// The user is responsible for ensuring that this allocator
+// won't be used concurrently.
+// To make this sound, `UnsafeGlobalBlinkAlloc::new` and `UnsafeGlobalBlinkAlloc::new_in`
+// are marked unsafe.
+unsafe impl<A: Allocator + Sync> Sync for UnsafeGlobalBlinkAlloc<A> {}
+
+#[cfg(feature = "std")]
+impl UnsafeGlobalBlinkAlloc<std::alloc::System> {
+    /// Create a new [`UnsafeGlobalBlinkAlloc`].
+    ///
+    /// Const function can be used to initialize a static variable.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because this type is not thread-safe
+    /// but implements `Sync`.
+    /// Allocator returned by this method must not be used concurrently.
+    ///
+    /// For safer alternative see [`GlobalBlinkAlloc`](https://docs.rs/blink-alloc/0.2.2/blink_alloc/struct.GlobalBlinkAlloc.html).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use blink_alloc::UnsafeGlobalBlinkAlloc;
+    ///
+    /// // Safety: This program is single-threaded.
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: UnsafeGlobalBlinkAlloc = unsafe { UnsafeGlobalBlinkAlloc::new() };
+    ///
+    /// let _ = Box::new(42);
+    /// let _ = vec![1, 2, 3];
+    /// ```
+    pub const unsafe fn new() -> Self {
+        Self {
+            inner: BlinkAlloc::new_in(std::alloc::System),
+        }
+    }
+}
+
+impl<A> UnsafeGlobalBlinkAlloc<A>
+where
+    A: Allocator,
+{
+    /// Create a new [`UnsafeGlobalBlinkAlloc`]
+    /// with specified underlying allocator.
+    ///
+    /// Const function can be used to initialize a static variable.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because this type is not thread-safe
+    /// but implements `Sync`.
+    /// Allocator returned by this method must not be used concurrently.
+    ///
+    /// For safer alternative see [`GlobalBlinkAlloc`](https://docs.rs/blink-alloc/0.2.2/blink_alloc/struct.GlobalBlinkAlloc.html).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(feature = "std")] fn main() {
+    /// use blink_alloc::UnsafeGlobalBlinkAlloc;
+    ///
+    /// // Safety: This program is single-threaded.
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: UnsafeGlobalBlinkAlloc<std::alloc::System> = unsafe { UnsafeGlobalBlinkAlloc::new_in(std::alloc::System) };
+    ///
+    /// let _ = Box::new(42);
+    /// let _ = vec![1, 2, 3];
+    /// # }
+    /// # #[cfg(not(feature = "std"))] fn main() {}
+    /// ```
+    pub const unsafe fn new_in(alloc: A) -> Self {
+        Self {
+            inner: BlinkAlloc::new_in(alloc),
+        }
+    }
+
+    /// Resets this allocator, deallocating all chunks except the last one.
+    /// Last chunk will be reused.
+    /// With steady memory usage after few iterations
+    /// one chunk should be sufficient for all allocations between resets.
+    ///
+    /// # Safety
+    ///
+    /// Memory allocated from this allocator becomes invalidated.
+    /// The user is responsible to ensure that previously allocated memory
+    /// won't be used after reset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(feature = "std")] fn main() {
+    /// use blink_alloc::UnsafeGlobalBlinkAlloc;
+    ///
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: UnsafeGlobalBlinkAlloc = unsafe { UnsafeGlobalBlinkAlloc::new() };
+    ///
+    /// let b = Box::new(42);
+    /// let v = vec![1, 2, 3];
+    /// drop(b);
+    /// drop(v);
+    ///
+    /// // Safety: allocated memory won't be used after reset.
+    /// unsafe { GLOBAL_ALLOC.reset() };
+    /// # }
+    /// # #[cfg(not(feature = "std"))] fn main() {}
+    /// ```
+    #[inline(always)]
+    pub unsafe fn reset(&self) {
+        self.inner.reset_unchecked();
+    }
+}
+
+unsafe impl<A> GlobalAlloc for UnsafeGlobalBlinkAlloc<A>
+where
+    A: Allocator,
+{
+    #[inline]
+    unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
+        match self.inner.allocate(layout) {
+            Ok(ptr) => ptr.as_ptr().cast(),
+            Err(_) => null_mut(),
+        }
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
+        if let Some(ptr) = NonNull::new(ptr) {
+            self.inner.deallocate(ptr, layout.size());
+        }
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: core::alloc::Layout) -> *mut u8 {
+        match self.inner.allocate_zeroed(layout) {
+            Ok(ptr) => ptr.as_ptr().cast(),
+            Err(_) => null_mut(),
+        }
+    }
+
+    #[inline]
+    unsafe fn realloc(
+        &self,
+        ptr: *mut u8,
+        layout: core::alloc::Layout,
+        new_size: usize,
+    ) -> *mut u8 {
+        let Ok(new_layout) = Layout::from_size_align(new_size, layout.align()) else {
+            return null_mut();
+        };
+
+        let result = match NonNull::new(ptr) {
+            None => self.inner.allocate(new_layout),
+            Some(ptr) => self.inner.resize(ptr, layout, new_layout),
+        };
+
+        match result {
+            Ok(ptr) => ptr.as_ptr().cast(),
+            Err(_) => null_mut(),
+        }
+    }
+}

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -1,0 +1,6 @@
+//! This module provide types suitable for use as `#[global_allocator]`.
+//!
+
+pub mod local;
+#[cfg(feature = "sync")]
+pub mod sync;

--- a/src/global/sync.rs
+++ b/src/global/sync.rs
@@ -181,7 +181,7 @@ where
             );
         }
 
-        (&*self.inner.get()).reset_unchecked();
+        (*self.inner.get()).reset_unchecked();
     }
 
     /// Refreshes scope of this allocator.
@@ -287,7 +287,7 @@ where
 {
     #[inline]
     unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
-        match (&*self.inner.get()).allocate(layout) {
+        match (*self.inner.get()).allocate(layout) {
             Ok(ptr) => {
                 #[cfg(debug_assertions)]
                 {
@@ -302,7 +302,7 @@ where
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
         let ptr = NonNull::new_unchecked(ptr);
-        (&*self.inner.get()).deallocate(ptr, layout.size());
+        (*self.inner.get()).deallocate(ptr, layout.size());
         #[cfg(debug_assertions)]
         {
             let _ = self
@@ -315,7 +315,7 @@ where
 
     #[inline]
     unsafe fn alloc_zeroed(&self, layout: core::alloc::Layout) -> *mut u8 {
-        match (&*self.inner.get()).allocate_zeroed(layout) {
+        match (*self.inner.get()).allocate_zeroed(layout) {
             Ok(ptr) => {
                 #[cfg(debug_assertions)]
                 {
@@ -339,8 +339,8 @@ where
         };
 
         let result = match NonNull::new(ptr) {
-            None => (&*self.inner.get()).allocate(new_layout),
-            Some(ptr) => (&*self.inner.get()).resize(ptr, layout, new_layout),
+            None => (*self.inner.get()).allocate(new_layout),
+            Some(ptr) => (*self.inner.get()).resize(ptr, layout, new_layout),
         };
 
         match result {

--- a/src/global/sync.rs
+++ b/src/global/sync.rs
@@ -1,0 +1,207 @@
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    ptr::{null_mut, NonNull},
+};
+
+use allocator_api2::alloc::Allocator;
+
+use crate::{sync::SyncBlinkAlloc, LocalBlinkAlloc};
+
+switch_std_default! {
+    /// [`GlobalAlloc`] implementation based on [`SyncBlinkAlloc`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use blink_alloc::GlobalBlinkAlloc;
+    ///
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: GlobalBlinkAlloc = GlobalBlinkAlloc::new();
+    ///
+    /// fn main() {
+    ///     let _ = Box::new(42);
+    ///     let _ = vec![1, 2, 3];
+    /// }
+    /// ```
+    pub struct GlobalBlinkAlloc<A: Allocator = +std::alloc::System> {
+        inner: SyncBlinkAlloc<A>,
+    }
+}
+
+#[cfg(feature = "std")]
+impl GlobalBlinkAlloc<std::alloc::System> {
+    /// Create a new [`GlobalBlinkAlloc`].
+    ///
+    /// Const function can be used to initialize a static variable.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use blink_alloc::GlobalBlinkAlloc;
+    ///
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: GlobalBlinkAlloc = GlobalBlinkAlloc::new();
+    ///
+    /// fn main() {
+    ///     let _ = Box::new(42);
+    ///     let _ = vec![1, 2, 3];
+    /// }
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            inner: SyncBlinkAlloc::new_in(std::alloc::System),
+        }
+    }
+}
+
+impl<A> GlobalBlinkAlloc<A>
+where
+    A: Allocator,
+{
+    /// Create a new [`GlobalBlinkAlloc`]
+    /// with specified underlying allocator.
+    ///
+    /// Const function can be used to initialize a static variable.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use blink_alloc::GlobalBlinkAlloc;
+    ///
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: GlobalBlinkAlloc<std::alloc::System> = GlobalBlinkAlloc::new_in(std::alloc::System);
+    ///
+    /// fn main() {
+    ///     let _ = Box::new(42);
+    ///     let _ = vec![1, 2, 3];
+    /// }
+    /// ```
+    pub const fn new_in(alloc: A) -> Self {
+        Self {
+            inner: SyncBlinkAlloc::new_in(alloc),
+        }
+    }
+
+    /// Resets this allocator, deallocating all chunks except the last one.
+    /// Last chunk will be reused.
+    /// With steady memory usage after few iterations
+    /// one chunk should be sufficient for all allocations between resets.
+    ///
+    /// # Safety
+    ///
+    /// Memory allocated from this allocator becomes invalidated.
+    /// The user is responsible to ensure that previously allocated memory
+    /// won't be used after reset.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use blink_alloc::GlobalBlinkAlloc;
+    ///
+    /// #[global_allocator]
+    /// static GLOBAL_ALLOC: GlobalBlinkAlloc = GlobalBlinkAlloc::new();
+    ///
+    /// fn main() {
+    ///     let b = Box::new(42);
+    ///     let v = vec![1, 2, 3];
+    ///     drop(b);
+    ///     drop(v);
+    ///
+    ///     // Safety: allocated memory won't be used after reset.
+    ///     unsafe { GLOBAL_ALLOC.reset() };
+    /// }
+    /// ```
+    #[inline(always)]
+    pub unsafe fn reset(&self) {
+        self.inner.reset_unchecked();
+    }
+
+    /// Creates a new thread-local blink allocator proxy
+    /// that borrows from this multi-threaded allocator.
+    ///
+    /// The local proxy allocator works faster and
+    /// allows more consistent memory reuse.
+    /// It can be recreated without resetting the multi-threaded allocator,
+    /// allowing [`SyncBlinkAlloc`] to be warm-up and serve all allocations
+    /// from a single chunk without ever blocking.
+    ///
+    /// Best works for fork-join style of parallelism.
+    /// Create a local allocator for each thread/task.
+    /// Reset after all threads/tasks are finished.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![cfg_attr(feature = "nightly", feature(allocator_api))]
+    /// # use blink_alloc::GlobalBlinkAlloc;
+    /// # use allocator_api2::vec::Vec;
+    /// # fn main() {
+    /// static BLINK: GlobalBlinkAlloc = GlobalBlinkAlloc::new();
+    /// for _ in 0..3 {
+    ///     for i in 0..16 {
+    ///         std::thread::scope(|_| {
+    ///             let blink = BLINK.local();
+    ///             let mut vec = Vec::new_in(&blink);
+    ///             vec.push(i);
+    ///             for j in i*2..i*30 {
+    ///                 vec.push(j); // Proxy will allocate enough memory to grow vec without reallocating on 2nd iteration and later.
+    ///             }
+    ///         });
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    pub fn local(&self) -> LocalBlinkAlloc<'_, A> {
+        self.inner.local()
+    }
+}
+
+unsafe impl<A> GlobalAlloc for GlobalBlinkAlloc<A>
+where
+    A: Allocator,
+{
+    #[inline]
+    unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
+        match self.inner.allocate(layout) {
+            Ok(ptr) => ptr.as_ptr().cast(),
+            Err(_) => null_mut(),
+        }
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
+        if let Some(ptr) = NonNull::new(ptr) {
+            self.inner.deallocate(ptr, layout.size());
+        }
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: core::alloc::Layout) -> *mut u8 {
+        match self.inner.allocate_zeroed(layout) {
+            Ok(ptr) => ptr.as_ptr().cast(),
+            Err(_) => null_mut(),
+        }
+    }
+
+    #[inline]
+    unsafe fn realloc(
+        &self,
+        ptr: *mut u8,
+        layout: core::alloc::Layout,
+        new_size: usize,
+    ) -> *mut u8 {
+        let Ok(new_layout) = Layout::from_size_align(new_size, layout.align()) else {
+            return null_mut();
+        };
+
+        let result = match NonNull::new(ptr) {
+            None => self.inner.allocate(new_layout),
+            Some(ptr) => self.inner.resize(ptr, layout, new_layout),
+        };
+
+        match result {
+            Ok(ptr) => ptr.as_ptr().cast(),
+            Err(_) => null_mut(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,20 +17,20 @@ macro_rules! feature_switch {
 
 #[allow(unused)]
 macro_rules! with_default {
-    ($(#[$meta:meta])* $v:vis struct $name:ident<$($lt:lifetime,)* $($generic:ident $(: $bound:path $(: $bounds:path )*)? $(= +$default:ty)? $(= $default_type:ty)?),+> { $($fvis:vis $fname:ident: $ftype:ty),* $(,)? }) => {
+    ($(#[$meta:meta])* $v:vis struct $name:ident<$($lt:lifetime,)* $($generic:ident $(: $bound:path $(: $bounds:path )*)? $(= +$default:ty)? $(= $default_type:ty)?),+> { $($(#[$fmeta:meta])*  $fvis:vis $fname:ident: $ftype:ty),* $(,)? }) => {
         $(#[$meta])*
         $v struct $name<$($lt,)* $($generic $(: $bound $(+ $bounds)*)? $(= $default)? $(= $default_type)?)+> {
-            $($fvis $fname: $ftype,)*
+            $($(#[$fmeta])* $fvis $fname: $ftype,)*
         }
     };
 }
 
 #[allow(unused)]
 macro_rules! without_default {
-    ($(#[$meta:meta])* $v:vis struct $name:ident<$($lt:lifetime,)* $($generic:ident $(: $bound:path $(: $bounds:path )*)? $(= +$default:ty)? $(= $default_type:ty)?),+> { $($fvis:vis $fname:ident: $ftype:ty),* $(,)? }) => {
+    ($(#[$meta:meta])* $v:vis struct $name:ident<$($lt:lifetime,)* $($generic:ident $(: $bound:path $(: $bounds:path )*)? $(= +$default:ty)? $(= $default_type:ty)?),+> { $($(#[$fmeta:meta])* $fvis:vis $fname:ident: $ftype:ty),* $(,)? }) => {
         $(#[$meta])*
         $v struct $name<$($lt,)* $($generic $(: $bound $(+ $bounds)*)? $(= $default_type)?)+> {
-            $($fvis $fname: $ftype,)*
+            $($(#[$fmeta])* $fvis $fname: $ftype,)*
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,3 +105,14 @@ unsafe fn in_place<'a, T, I>(ptr: *mut T, init: I, f: impl FnOnce(I) -> T) -> &'
 
 #[cold]
 fn cold() {}
+
+#[cfg(debug_assertions)]
+#[track_caller]
+unsafe fn unreachable_unchecked() -> ! {
+    unreachable!()
+}
+
+#[cfg(not(debug_assertions))]
+unsafe fn unreachable_unchecked() -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}

--- a/src/local.rs
+++ b/src/local.rs
@@ -329,7 +329,7 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        BlinkAlloc::resize(&self, ptr, old_layout, new_layout)
+        BlinkAlloc::resize(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -349,12 +349,12 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        BlinkAlloc::resize_zeroed(&self, ptr, old_layout, new_layout)
+        BlinkAlloc::resize_zeroed(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        BlinkAlloc::deallocate(&self, ptr, layout.size());
+        BlinkAlloc::deallocate(self, ptr, layout.size());
     }
 }
 
@@ -379,7 +379,7 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        BlinkAlloc::resize(&self, ptr, old_layout, new_layout)
+        BlinkAlloc::resize(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -399,12 +399,12 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        BlinkAlloc::resize_zeroed(&self, ptr, old_layout, new_layout)
+        BlinkAlloc::resize_zeroed(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        BlinkAlloc::deallocate(&self, ptr, layout.size());
+        BlinkAlloc::deallocate(self, ptr, layout.size());
     }
 }
 

--- a/src/local.rs
+++ b/src/local.rs
@@ -154,6 +154,12 @@ where
         }
     }
 
+    /// Returns reference to the underlying allocator used by this blink allocator.
+    #[inline(always)]
+    pub const fn inner(&self) -> &A {
+        &self.allocator
+    }
+
     /// Creates new blink allocator that uses global allocator
     /// to allocate memory chunks.
     /// With this method you can specify initial chunk size.

--- a/src/local.rs
+++ b/src/local.rs
@@ -63,7 +63,6 @@ with_global_default! {
     ///
     /// unsafe {
     ///     std::ptr::write(ptr.as_ptr().cast(), [1, 2, 3, 4, 5, 6, 7, 8]);
-    ///     blink.deallocate(ptr, layout.size());
     /// }
     ///
     /// blink.reset();
@@ -207,21 +206,8 @@ where
         // Same instance is used for all allocations and resets.
         // `ptr` was allocated by this allocator.
         unsafe {
-            if old_layout.align() >= new_layout.align() {
-                self.arena.resize::<false, true>(
-                    ptr,
-                    old_layout.size(),
-                    new_layout,
-                    &self.allocator,
-                )
-            } else {
-                self.arena.resize::<false, false>(
-                    ptr,
-                    old_layout.size(),
-                    new_layout,
-                    &self.allocator,
-                )
-            }
+            self.arena
+                .resize::<false>(ptr, old_layout, new_layout, &self.allocator)
         }
     }
 
@@ -241,39 +227,30 @@ where
         // Same instance is used for all allocations and resets.
         // `ptr` was allocated by this allocator.
         unsafe {
-            if old_layout.align() >= new_layout.align() {
-                self.arena
-                    .resize::<true, true>(ptr, old_layout.size(), new_layout, &self.allocator)
-            } else {
-                self.arena.resize::<true, false>(
-                    ptr,
-                    old_layout.size(),
-                    new_layout,
-                    &self.allocator,
-                )
-            }
+            self.arena
+                .resize::<true>(ptr, old_layout, new_layout, &self.allocator)
         }
     }
 
-    /// Deallocates memory previously allocated from this allocator.
-    ///
-    /// This call may not actually free memory.
-    /// All memory is guaranteed to be freed on [`reset`](BlinkAlloc::reset) call.
-    ///
-    /// # Safety
-    ///
-    /// `ptr` must be a pointer previously returned by [`allocate`](BlinkAlloc::allocate).
-    /// `size` must be in range `layout.size()..=slice.len()`
-    /// where `layout` is the layout used in the call to [`allocate`](BlinkAlloc::allocate).
-    /// and `slice` is the slice pointer returned by [`allocate`](BlinkAlloc::allocate).
-    #[inline(always)]
-    pub unsafe fn deallocate(&self, ptr: NonNull<u8>, size: usize) {
-        // Safety:
-        // `ptr` was allocated by this allocator.
-        unsafe {
-            self.arena.dealloc(ptr, size);
-        }
-    }
+    // /// Deallocates memory previously allocated from this allocator.
+    // ///
+    // /// This call may not actually free memory.
+    // /// All memory is guaranteed to be freed on [`reset`](BlinkAlloc::reset) call.
+    // ///
+    // /// # Safety
+    // ///
+    // /// `ptr` must be a pointer previously returned by [`allocate`](BlinkAlloc::allocate).
+    // /// `size` must be in range `layout.size()..=slice.len()`
+    // /// where `layout` is the layout used in the call to [`allocate`](BlinkAlloc::allocate).
+    // /// and `slice` is the slice pointer returned by [`allocate`](BlinkAlloc::allocate).
+    // #[inline(always)]
+    // pub unsafe fn deallocate(&self, ptr: NonNull<u8>, size: usize) {
+    //     // Safety:
+    //     // `ptr` was allocated by this allocator.
+    //     unsafe {
+    //         self.arena.dealloc(ptr, size);
+    //     }
+    // }
 
     /// Resets this allocator, deallocating all chunks except the last one.
     /// Last chunk will be reused.
@@ -335,7 +312,8 @@ where
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        BlinkAlloc::deallocate(&self, ptr, layout.size());
+        // BlinkAlloc::deallocate(&self, ptr, layout.size());
+        drop((ptr, layout));
     }
 }
 
@@ -385,7 +363,7 @@ where
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        BlinkAlloc::deallocate(&self, ptr, layout.size());
+        drop((ptr, layout));
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -160,6 +160,12 @@ where
         }
     }
 
+    /// Returns reference to the underlying allocator used by this blink allocator.
+    #[inline(always)]
+    pub const fn inner(&self) -> &A {
+        &self.allocator
+    }
+
     /// Creates new blink allocator that uses global allocator
     /// to allocate memory chunks.
     /// With this method you can specify initial chunk size.

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -391,7 +391,7 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        SyncBlinkAlloc::resize(&self, ptr, old_layout, new_layout)
+        SyncBlinkAlloc::resize(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -411,7 +411,7 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        SyncBlinkAlloc::resize_zeroed(&self, ptr, old_layout, new_layout)
+        SyncBlinkAlloc::resize_zeroed(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -441,7 +441,7 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        SyncBlinkAlloc::resize(&self, ptr, old_layout, new_layout)
+        SyncBlinkAlloc::resize(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -461,7 +461,7 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        SyncBlinkAlloc::resize_zeroed(&self, ptr, old_layout, new_layout)
+        SyncBlinkAlloc::resize_zeroed(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -647,7 +647,7 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        LocalBlinkAlloc::resize(&self, ptr, old_layout, new_layout)
+        LocalBlinkAlloc::resize(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -667,12 +667,12 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        LocalBlinkAlloc::resize_zeroed(&self, ptr, old_layout, new_layout)
+        LocalBlinkAlloc::resize_zeroed(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        LocalBlinkAlloc::deallocate(&self, ptr, layout.size())
+        LocalBlinkAlloc::deallocate(self, ptr, layout.size())
     }
 }
 
@@ -697,7 +697,7 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        LocalBlinkAlloc::resize(&self, ptr, old_layout, new_layout)
+        LocalBlinkAlloc::resize(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
@@ -717,12 +717,12 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        LocalBlinkAlloc::resize_zeroed(&self, ptr, old_layout, new_layout)
+        LocalBlinkAlloc::resize_zeroed(self, ptr, old_layout, new_layout)
     }
 
     #[inline(always)]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        LocalBlinkAlloc::deallocate(&self, ptr, layout.size())
+        LocalBlinkAlloc::deallocate(self, ptr, layout.size())
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -92,27 +92,27 @@ fn test_reuse() {
 
     let mut alloc = BlinkAlloc::with_chunk_size_in(0, &allocator);
 
-    for i in 0..123 {
-        dbg!(i);
+    for _ in 0..123 {
         alloc.allocate(Layout::new::<u32>()).unwrap();
     }
     alloc.reset();
 
     allocator.last.set(false);
 
-    for i in 0..123 {
-        dbg!(i);
+    for _ in 0..123 {
         alloc.allocate(Layout::new::<u32>()).unwrap();
     }
 }
 
 #[test]
 fn test_emplace_no_drop() {
+    use alloc::{borrow::ToOwned, string::String};
+
     struct Foo<'a>(&'a String);
 
     impl Drop for Foo<'_> {
         fn drop(&mut self) {
-            println!("{}", self.0);
+            panic!("Dropped");
         }
     }
 


### PR DESCRIPTION
This PR adds global allocators that use blink-allocators under the hood.
It is not as simple to use and resets are inherently unsafe since there's no way to ensure that all allocations were dropped.
However if resets are not required the usage is safe for multi-threaded version - `GlobalAlloc`.
Thread-local version named `UnsafeGlobalAlloc` can be used with care in single-threaded applications.

This diff is rather large as I was also fixing doc-test issues with different features enabled.

Addresses #2 