### PR TITLE
Implement `Drop` for `Blink` adapter

### DIFF
--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -11,14 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+      uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --features=sync
+      run: cargo test --all --features=sync

--- a/.github/workflows/check-platforms.yml
+++ b/.github/workflows/check-platforms.yml
@@ -15,14 +15,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+      uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --features=sync
+      run: cargo check --all --features=sync

--- a/.github/workflows/check-targets.yml
+++ b/.github/workflows/check-targets.yml
@@ -23,15 +23,10 @@ jobs:
         - x86_64-unknown-linux-gnu
         - wasm32-unknown-unknown
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        profile: minimal
-        toolchain: stable
         target: ${{ matrix.target }}
     - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --features=sync
+      run: cargo check --all --features=sync

--- a/.github/workflows/check-toolchains.yml
+++ b/.github/workflows/check-toolchains.yml
@@ -15,14 +15,10 @@ jobs:
       matrix:
         rust-toolchain: [stable, nightly]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install ${{ matrix.rust-toolchain }} toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust-toolchain }}
     - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --features=sync
+      run: cargo check --all --features=sync

--- a/.github/workflows/fast-pr-check.yml
+++ b/.github/workflows/fast-pr-check.yml
@@ -15,14 +15,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
+      uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Run cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --features sync
+      run: cargo test --all --features=sync

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -15,30 +15,27 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install nightly toolchain
-      uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+    - name: Ensure rustfmt is installed
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        profile: minimal
         toolchain: nightly
-    - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+        components: rustfmt   
+    - name: Rustfmt check
+      uses: actions-rust-lang/rustfmt@v1
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install nightly toolchain with clippy available
-      uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v4
+    - name: Ensure clippy is installed
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        profile: minimal
         toolchain: nightly
-        components: rustfmt
+        components: clippy
     - name: Run cargo clippy
-      uses: actions-rs/clippy-check@v1
+      uses: giraffate/clippy-action@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all --all-features -- -D warnings
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        clippy_flags: --all --all-features -- -D warnings
+        reporter: 'github-pr-review'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,10 @@
+name: release-please
+
 on:
   push:
     branches:
       - main
-name: release-please
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event.label.name == 'ready-to-merge' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/audit-check@v1
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/audit@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-features.yml
+++ b/.github/workflows/test-features.yml
@@ -17,14 +17,10 @@ jobs:
         sync: ["", "sync,"]
         nightly: ["", "nightly,"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install nightly toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        profile: minimal
         toolchain: nightly
-    - name: Run cargo check
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --features=${{ matrix.std }}${{ matrix.sync }}${{ matrix.nightly }}
+    - name: Run cargo test
+      run: cargo test --all --features=${{ matrix.std }}${{ matrix.sync }}${{ matrix.nightly }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["std"]
 
 [dependencies]
 parking_lot = { version = "0.12", optional = true }
-allocator-api2 = { version = "0.2.8", default-features = false, path = "../allocator-api2" }
+allocator-api2 = { version = "0.2.8", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/arena/local.rs
+++ b/src/arena/local.rs
@@ -57,6 +57,7 @@ impl ArenaLocal {
         }
         None
     }
+
     #[inline(always)]
     pub unsafe fn alloc_slow(
         &self,

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -46,7 +46,8 @@ fn layout_sum(layout: &Layout) -> usize {
     layout.size() + (layout.align() - 1)
 }
 
-pub trait CasPtr {
+pub(crate) trait CasPtr {
+    #[allow(dead_code)]
     fn new(value: *mut u8) -> Self;
     fn load(&self, order: Ordering) -> *mut u8;
     fn set(&mut self, value: *mut u8);

--- a/src/arena/mod.rs
+++ b/src/arena/mod.rs
@@ -185,8 +185,8 @@ macro_rules! with_cursor {
                 prev: Option<NonNull<Self>>,
             ) -> Result<NonNull<Self>, AllocError> {
                 let Some(size) = align_up(size, align_of::<Self>()) else {
-                                                                            return Err(AllocError);
-                                                                        };
+                    return Err(AllocError);
+                };
 
                 // Safety:
                 // size + (align - 1) hasn't overflow above.
@@ -483,7 +483,8 @@ macro_rules! with_cursor {
             if chunk_size < CHUNK_POWER_OF_TWO_THRESHOLD {
                 chunk_size = chunk_size.next_power_of_two();
             } else {
-                chunk_size = align_up(chunk_size, CHUNK_POWER_OF_TWO_THRESHOLD).unwrap_or(chunk_size);
+                chunk_size =
+                    align_up(chunk_size, CHUNK_POWER_OF_TWO_THRESHOLD).unwrap_or(chunk_size);
             }
 
             debug_assert_eq!(chunk_size % align_of::<ChunkHeader>(), 0);
@@ -516,11 +517,7 @@ macro_rules! with_cursor {
         }
 
         #[inline(always)]
-        pub unsafe fn dealloc(
-            root: Option<NonNull<ChunkHeader>>,
-            ptr: NonNull<u8>,
-            size: usize,
-        ) {
+        pub unsafe fn dealloc(root: Option<NonNull<ChunkHeader>>, ptr: NonNull<u8>, size: usize) {
             if let Some(root) = root {
                 // Safety:
                 // `chunk` is a valid pointer to chunk allocation.

--- a/src/blink.rs
+++ b/src/blink.rs
@@ -199,6 +199,13 @@ switch_alloc_default! {
     }
 }
 
+impl<A> Drop for Blink<A> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        self.drop_all();
+    }
+}
+
 // Safety: `Blink` is not auto-send because of `DropList`.
 // The `DropList` contains pointers to objects allocated from `Blink`.
 // If `Blink` is moved to another thread (or `&mut Blink`) then all returned pointers
@@ -579,7 +586,8 @@ where
 
         loop {
             let (lower, upper) = iter.size_hint();
-            let Some(size_hint) = size_hint_and_one(lower, upper, guard.count.max(FASTER_START)) else {
+            let Some(size_hint) = size_hint_and_one(lower, upper, guard.count.max(FASTER_START))
+            else {
                 return Err(err(guard.flush(), one_more, None));
             };
 
@@ -746,7 +754,8 @@ where
 
         loop {
             let (lower, upper) = iter.size_hint();
-            let Some(size_hint) = size_hint_and_one(lower, upper, guard.count.max(FASTER_START)) else {
+            let Some(size_hint) = size_hint_and_one(lower, upper, guard.count.max(FASTER_START))
+            else {
                 return Err(err(guard.flush(), one_more, None));
             };
 

--- a/src/blink.rs
+++ b/src/blink.rs
@@ -1442,9 +1442,7 @@ fn size_hint_and_one(lower: usize, upper: Option<usize>, count: usize) -> Option
     let size_hint = lower.max(upper);
 
     // Add one more element to size hint.
-    let Some(size_hint) = size_hint.checked_add(1) else {
-        return None;
-    };
+    let size_hint = size_hint.checked_add(1)?;
 
     // Sum with current count.
     count.checked_add(size_hint)

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -479,7 +479,7 @@ where
         if let Some(ptr) = unsafe { self.arena.alloc_fast(layout) } {
             return Ok(ptr);
         }
-        unsafe { self.arena.alloc_slow(layout, &self.shared) }
+        unsafe { self.arena.alloc_slow(layout, self.shared) }
     }
 
     /// Resizes memory allocation.
@@ -510,7 +510,7 @@ where
         // `ptr` was allocated by this allocator.
         unsafe {
             self.arena
-                .resize_slow(ptr, old_layout, new_layout, &self.shared)
+                .resize_slow(ptr, old_layout, new_layout, self.shared)
         }
     }
 


### PR DESCRIPTION
`Blink` adapter docs contains:
```
/// [`Blink`] calls [`Drop::drop`] for emplaced values when reset or dropped.
```
But in fact it only does this when reset.
